### PR TITLE
Fix: static datasource ids

### DIFF
--- a/resource-optimization-dashboard.json
+++ b/resource-optimization-dashboard.json
@@ -150,8 +150,7 @@
         },
         {
             "datasource": {
-                "type": "prometheus",
-                "uid": "aem10zgj3nj7kf"
+                "type": "prometheus"
             },
             "fieldConfig": {
                 "defaults": {
@@ -426,8 +425,7 @@
         },
         {
             "datasource": {
-                "type": "prometheus",
-                "uid": "aem10zgj3nj7kf"
+                "type": "prometheus"
             },
             "fieldConfig": {
                 "defaults": {
@@ -495,8 +493,7 @@
         },
         {
             "datasource": {
-                "type": "prometheus",
-                "uid": "aem10zgj3nj7kf"
+                "type": "prometheus"
             },
             "fieldConfig": {
                 "defaults": {
@@ -561,8 +558,7 @@
         },
         {
             "datasource": {
-                "type": "prometheus",
-                "uid": "aem10zgj3nj7kf"
+                "type": "prometheus"
             },
             "fieldConfig": {
                 "defaults": {
@@ -627,8 +623,7 @@
         },
         {
             "datasource": {
-                "type": "prometheus",
-                "uid": "aem10zgj3nj7kf"
+                "type": "prometheus"
             },
             "fieldConfig": {
                 "defaults": {

--- a/resource-optimization-dashboard.json
+++ b/resource-optimization-dashboard.json
@@ -23,7 +23,8 @@
     "panels": [
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -150,7 +151,8 @@
         },
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -425,7 +427,8 @@
         },
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -493,7 +496,8 @@
         },
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -558,7 +562,8 @@
         },
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -623,7 +628,8 @@
         },
         {
             "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "${datasource}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -695,7 +701,21 @@
         "cost-optimization"
     ],
     "templating": {
-        "list": []
+      "list": [
+        {
+          "current": {
+            "text": "Prometheus",
+            "value": "prometheus"
+          },
+          "label": "Data Source",
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        }
+      ]
     },
     "time": {
         "from": "now-1h",


### PR DESCRIPTION
Remove hardcoded Prometheus datasource UIDs from dashboard JSON

## Why
The dashboard JSON currently hardcodes Prometheus datasource uid/id values. These values differ between Grafana instances and orgs, which often causes an “unknown datasource uid” / “data source not found” error during import. When a user has only one Prometheus datasource (or a default Prometheus datasource set), Grafana can resolve it automatically during import, as long as the dashboard doesn’t pin a specific UID.

## What changed
- Removed static Prometheus datasource uid/id bindings from all panels/queries.
- Kept the datasource type as Prometheus so Grafana can auto-select the only/default Prometheus datasource at import time.
- No query logic or panel configuration was changed.